### PR TITLE
Removed bottle :uneeded

### DIFF
--- a/vibes-rabbitmq.rb
+++ b/vibes-rabbitmq.rb
@@ -4,7 +4,6 @@ class VibesRabbitmq < Formula
   url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.1/rabbitmq-server-generic-unix-3.8.1.tar.xz"
   sha256 "a21f012ba71dfe192763aad1384388b8dd0d9907ae61ce6d0b3055d47dcf336e"
 
-  bottle :unneeded
 
   conflicts_with "rabbitmq",
     :because => "they are really the same thing"


### PR DESCRIPTION
brew no longer allows this. It was deprecated https://github.com/Homebrew/brew/commit/f65d525693a45c8e4c2ebc1452080f08c363ee15#diff-f12455e8eb757e3223300c7c544b5b752394173c2a9bb0440443d5673b151fb3

and was recently disabled https://github.com/Homebrew/brew/commit/38e1b3d64b1b7c88a2a0f25cefddc002bb703658